### PR TITLE
CON-3438: expose malware scanning options

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -39,6 +39,9 @@ jobs:
           hostname: ${{ secrets.UPTYCS_HOSTNAME }}
           image-id: ${{ steps.image_build_should_have_vulns.outputs.image_id }}
           secret-scanning-enabled: false
+          api-key: ${{ secrets.UPTYCS_API_KEY }}
+          api-secret: ${{ secrets.UPTYCS_API_SECRET }}
+          customer-id: ${{ secrets.UPTYCS_CUSTOMER_ID }}
 
       - name: Run Uptycs Scanner Expected to Have Secrets
         uses: uptycslabs/uptycs-action@main
@@ -48,6 +51,9 @@ jobs:
           hostname: ${{ secrets.UPTYCS_HOSTNAME }}
           image-id: ${{ steps.image_build_should_have_secrets.outputs.image_id }}
           vulnerabilities-enabled: false
+          api-key: ${{ secrets.UPTYCS_API_KEY }}
+          api-secret: ${{ secrets.UPTYCS_API_SECRET }}
+          customer-id: ${{ secrets.UPTYCS_CUSTOMER_ID 
 
       - name: Run Uptycs Scanner Expected to Succeed
         uses: uptycslabs/uptycs-action@main
@@ -56,3 +62,6 @@ jobs:
           hostname: ${{ secrets.UPTYCS_HOSTNAME }}
           image-id: ${{ steps.image_build_should_succeed.outputs.image_id }}
           secret-scanning-enabled: false
+          api-key: ${{ secrets.UPTYCS_API_KEY }}
+          api-secret: ${{ secrets.UPTYCS_API_SECRET }}
+          customer-id: ${{ secrets.UPTYCS_CUSTOMER_ID 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -32,7 +32,7 @@ jobs:
           echo "image_id=$(cat success_image_id.out)" >> $GITHUB_OUTPUT
 
       - name: Run Uptycs Scanner Expected to Have Vulns
-        uses: uptycslabs/uptycs-action@uptycs-ci-2-updates
+        uses: uptycslabs/uptycs-action@main
         continue-on-error: true
         with:
           uptycs-secret: ${{ secrets.UPTYCS_SECRET }}
@@ -41,7 +41,7 @@ jobs:
           secret-scanning-enabled: false
 
       - name: Run Uptycs Scanner Expected to Have Secrets
-        uses: uptycslabs/uptycs-action@uptycs-ci-2-updates
+        uses: uptycslabs/uptycs-action@main
         continue-on-error: true
         with:
           uptycs-secret: ${{ secrets.UPTYCS_SECRET }}
@@ -50,7 +50,7 @@ jobs:
           vulnerabilities-enabled: false
 
       - name: Run Uptycs Scanner Expected to Succeed
-        uses: uptycslabs/uptycs-action@uptycs-ci-2-updates
+        uses: uptycslabs/uptycs-action@main
         with:
           uptycs-secret: ${{ secrets.UPTYCS_SECRET }}
           hostname: ${{ secrets.UPTYCS_HOSTNAME }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -53,7 +53,7 @@ jobs:
           vulnerabilities-enabled: false
           api-key: ${{ secrets.UPTYCS_API_KEY }}
           api-secret: ${{ secrets.UPTYCS_API_SECRET }}
-          customer-id: ${{ secrets.UPTYCS_CUSTOMER_ID 
+          customer-id: ${{ secrets.UPTYCS_CUSTOMER_ID }}
 
       - name: Run Uptycs Scanner Expected to Succeed
         uses: uptycslabs/uptycs-action@main
@@ -64,4 +64,4 @@ jobs:
           secret-scanning-enabled: false
           api-key: ${{ secrets.UPTYCS_API_KEY }}
           api-secret: ${{ secrets.UPTYCS_API_SECRET }}
-          customer-id: ${{ secrets.UPTYCS_CUSTOMER_ID 
+          customer-id: ${{ secrets.UPTYCS_CUSTOMER_ID }}

--- a/action.yml
+++ b/action.yml
@@ -33,8 +33,15 @@ inputs:
     description: Enable or disable secret scanning.
     required: false
     default: true
+  malware-scanning-enabled:
+    description: Enable or disable malware scanning.
+    required: false
+    default: true
   secret-path:
     description: Path to scan for secrets.
+    required: false 
+  malware-path:
+    description: Path to scan for malware.
     required: false
   api-key:
     description: Tenant-specific key for authenticating to the uptycs API. Required if enabling grace-period.
@@ -77,4 +84,4 @@ runs:
           "${{ inputs['image-id'] }}" \
           "${{ inputs['uptycs-secret'] }}" \
           "${{ inputs['hostname'] }}" \
-          "{\"vulnerabilities_enabled\": \"${{ inputs['vulnerabilities-enabled'] }}\",\"secrets_enabled\": \"${{ inputs['secret-scanning-enabled'] }}\",\"secret_path\": \"${{ inputs['secret-path'] }}\",\"api_key\": \"${{ inputs['api-key'] }}\",\"api_secret\": \"${{ inputs['api-secret'] }}\",\"customer_id\": \"${{ inputs['customer-id'] }}\",\"grace_period\": \"${{ inputs['grace-period'] }}\",\"ignore_no_fix\": \"${{ inputs['ignore-no-fix'] }}\",\"custom-ca-cert\": \"${{ inputs['custom-ca-cert'] }}\"}"
+          "{\"vulnerabilities_enabled\": \"${{ inputs['vulnerabilities-enabled'] }}\",\"secrets_enabled\": \"${{ inputs['secret-scanning-enabled'] }}\",\"malware_enabled\": \"${{ inputs['malware-scanning-enabled'] }}\",\"secret_path\": \"${{ inputs['secret-path'] }}\",\"malware_path\": \"${{ inputs['malware-path'] }}\",\"api_key\": \"${{ inputs['api-key'] }}\",\"api_secret\": \"${{ inputs['api-secret'] }}\",\"customer_id\": \"${{ inputs['customer-id'] }}\",\"grace_period\": \"${{ inputs['grace-period'] }}\",\"ignore_no_fix\": \"${{ inputs['ignore-no-fix'] }}\",\"custom-ca-cert\": \"${{ inputs['custom-ca-cert'] }}\"}"


### PR DESCRIPTION
This PR adds support for additional malware scanning options in the github action yaml. Additionally, the CI pipeline is updated to use the `main` branch of the github action.