### PR TITLE
CON-6119: bump uptycs-cli to 3.5.2

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -35,21 +35,21 @@ jobs:
           echo "image_id=$(cat success_image_id.out)" >> $GITHUB_OUTPUT
 
       - name: Run Uptycs Scanner Expected to Have Vulns
-        uses: uptycslabs/uptycs-action@CON-5687
+        uses: uptycslabs/uptycs-action@main
         continue-on-error: true
         with:
           image: ${{ steps.image_build_should_have_vulns.outputs.image_id }}
           credentials: ${{ secrets.UPTYCS_CREDENTIALS }}
 
       - name: Run Uptycs Scanner Expected to Have Secrets
-        uses: uptycslabs/uptycs-action@CON-5687
+        uses: uptycslabs/uptycs-action@main
         continue-on-error: true
         with:
           image: ${{ steps.image_build_should_have_secrets.outputs.image_id }}
           credentials: ${{ secrets.UPTYCS_CREDENTIALS }}
 
       - name: Run Uptycs Scanner Expected to Succeed
-        uses: uptycslabs/uptycs-action@CON-5687
+        uses: uptycslabs/uptycs-action@main
         with:
           image: ${{ steps.image_build_should_succeed.outputs.image_id }}
           credentials: ${{ secrets.UPTYCS_CREDENTIALS }}

--- a/action.yml
+++ b/action.yml
@@ -51,7 +51,7 @@ inputs:
   version:
     description: The version of uptycs-cli to use when scanning.
     required: false
-    default: 3.5.0
+    default: 3.5.2
 runs:
   using: "composite"
   steps:


### PR DESCRIPTION
This PR bumps the default version of uptycs-cli to use the 3.5.2 release.