### PR TITLE
CON-6215: update to 3.5.3 release of uptycs-cli

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -51,7 +51,7 @@ inputs:
   version:
     description: The version of uptycs-cli to use when scanning.
     required: false
-    default: 3.5.2
+    default: 3.5.3
 runs:
   using: "composite"
   steps:


### PR DESCRIPTION
This PR updates the github action to use the latest 3.5.3 release of uptycs-cli.