### PR TITLE
CON-6246: bump uptycs-cli to 3.5.4 release

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -51,7 +51,7 @@ inputs:
   version:
     description: The version of uptycs-cli to use when scanning.
     required: false
-    default: 3.5.3
+    default: 3.5.4
 runs:
   using: "composite"
   steps:


### PR DESCRIPTION
This PR bumps the version of uptycs-cli to 3.5.4