### PR TITLE
CON-6479: Pin uptycs-ci image version to 3.5.8

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -40,7 +40,7 @@ inputs:
   scanner-image:
     description: The uptycs-ci image to use when executing the scan.
     required: false
-    default: "uptycs/uptycs-ci:latest"
+    default: "uptycs/uptycs-ci:3.5.8"
   uptycs-ca-cert:
     description: The path to a custom CA Cert to use for connecting to uptycs.
     required: false


### PR DESCRIPTION
- Changes to pin `uptycs-ci` image version to `3.5.8`